### PR TITLE
ShovlrImportrQueueable

### DIFF
--- a/src/classes/ShovlrImportrQueueable.cls
+++ b/src/classes/ShovlrImportrQueueable.cls
@@ -1,0 +1,65 @@
+
+public class ShovlrImportrQueueable implements Queueable {
+
+    Integer counter { get; set; }
+    Data_Shover_Setting__mdt settings { get; set; }
+
+    public ShovlrImportrQueueable() {
+        counter = 0;
+        settings = [
+                SELECT Object_Name__c, Limit__c, Sequence__c
+                FROM Data_Shover_Setting__mdt
+                ORDER BY Sequence__c
+        ][counter];
+    }
+
+    public ShovlrImportrQueueable(Integer c, String sId) {
+        counter = c;
+        settings = [
+                SELECT Object_Name__c, Limit__c, Sequence__c
+                FROM Data_Shover_Setting__mdt
+                ORDER BY Sequence__c
+        ][counter];
+    }
+
+    public void execute(QueueableContext context) {
+        String srName = settings.Object_Name__c.replaceAll('_', '');
+        StaticResource sr = [SELECT Body FROM StaticResource WHERE Name = :srName];
+
+        Map<String, List<SObject>> dataMap = (Map<String, List<SObject>>)JSON.deserializeUntyped(sr.Body.toString());
+        List<SObject> soList = dataMap.values()[0];
+
+        Map<String, SObjectType> refFieldMap = defineRefFieldMap();
+
+        for(SObject so : soList) {
+            so.put('XC_Id__c', so.Id);
+            for(String refField : refFieldMap.keySet()) {
+                SObjectType refType = refFieldMap.get(refField);
+                SObject refObj = refType.newSObject();
+                refObj.put('XC_Id__c', String.valueOf(so.get(refField)));
+                so.put(refField, refObj);
+            }
+        }
+
+        Database.insert(soList);
+    }
+
+    Map<String, SObjectType> defineRefFieldMap() {
+        Map<String, SObjectType> refFieldMap = new Map<String, SObjectType>();
+
+        String objectName = settings.Object_Name__c;
+        Schema.DescribeSObjectResult dsr = Schema.getGlobalDescribe().get(objectName).getDescribe();
+
+        Map<String, Schema.SObjectField> fieldMap = dsr.fields.getMap();
+
+        for(String field : fieldMap.keySet()) {
+            Schema.SObjectField sof = fieldMap.get(field);
+            if(sof.getDescribe().getType() == Schema.DisplayType.REFERENCE) {
+                Schema.SObjectType soType = sof.getDescribe().getReferenceTo()[0];
+                refFieldMap.put(field, soType);
+            }
+        }
+
+        return refFieldMap;
+    }
+}

--- a/src/classes/ShovlrImportrQueueable.cls-meta.xml
+++ b/src/classes/ShovlrImportrQueueable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ShovlrUtil.cls
+++ b/src/classes/ShovlrUtil.cls
@@ -1,0 +1,16 @@
+
+public with sharing class ShovlrUtil {
+
+    MetadataService.MetadataPort createService(String sessionId) {
+        System.debug('ShovlrUtil ShovlrUtil');
+        MetadataService.MetadataPort service = new MetadataService.MetadataPort();
+        service.SessionHeader = new MetadataService.SessionHeader_element();
+        service.SessionHeader.sessionId = sessionId;
+        return service;
+    }
+
+    public static void createXCIdField(String objectName, String sessionId) {
+        MetadataService.MetadataPort svc = createService(sessionId);
+    }
+
+}

--- a/src/classes/ShovlrUtil.cls-meta.xml
+++ b/src/classes/ShovlrUtil.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
First draft of importer class.

Learned all about the voodoo involved in referencing external ids in relationship fields during creation DML (line 37-40).  Haven't tested it yet, but wanted to get this committed.

Also, this commit also includes ShovlrUtil class that I'm planning on using holding the functionality to create the XC_Id__c external id field on objects that do not yet have it.  I figured this removes another friction point so that we don't have to point/click add that field on any/all objcets that we're exporting.